### PR TITLE
GPS section to mobile mapping - German update

### DIFF
--- a/_posts/de/beginner/0200-12-18-more-about-josm.md
+++ b/_posts/de/beginner/0200-12-18-more-about-josm.md
@@ -185,17 +185,6 @@ Sie wissen jetzt, wie Sie Beiträge zu OpenStreetMap leisten können. Wie geht e
 bearbeiten ist zwar schön, aber zum Erstellen einer Karte gehört natürlich noch mehr. Sie müssen natürlich
 noch lernen, wie Sie in der realen Natur Informationen über die verschiedenen Objekte sammeln können.
 
-In den nächsten Abschnitten zeigen wir Ihnen zwei Methoden dazu - GPS und Field Papers,
-Damit kann man geographische Daten sammeln und diese in JOSM importieren, um die Karte zu bearbeiten.
-
-Nächste Schritte
-----------------
-
-Unter diesen Links erfahren Sie mehr über:  
- 
-*  [Kartierung mit GPS](/de/beginner/using-gps/)  
-*  [Field Papers](/de/beginner/field-papers/)
-*  [Editieren mit JOSM](/de/beginner/editing-with-josm/) 
 
 
 [JOSM Download Button]: /images/beginner/josm_download-button.png

--- a/_posts/de/beginner/0200-12-21-start-josm.md
+++ b/_posts/de/beginner/0200-12-21-start-josm.md
@@ -340,11 +340,10 @@ Zusammenfassung
 
 Hervorragend! Wenn alles gut gegangen ist hast du jetzt gelernt, wie 
 du den JOSM Editor auf deinem Computer installierst, und, wie du die 
-Werkzeuge benutzt um Karten zu zeichnen. In den nächsten beiden 
-Kapiteln wirst du den Umgang mit GPS-Geräten und "Field papers" lernen, 
-was dir helfen wird, deinen Wohnort zu kartieren. In Kapitel 6 kehren wir 
-zu JOSM zurück und benutzen die gesammelten Informationen, um Objekte
-auf OpenStreetMap einzutragen.
+Werkzeuge benutzt um Karten zu zeichnen. Später wirst du noch den Umgang 
+mit GPS-Geräten und "Field papers" lernen, 
+was dir helfen wird, deinen Wohnort zu kartieren. Dann benutzen wir
+die gesammelten Informationen, um Objekte auf OpenStreetMap einzutragen.
 
 Nächste Schritte
 ----------------

--- a/_posts/de/mobile-mapping/0900-12-25-gps-1.md
+++ b/_posts/de/mobile-mapping/0900-12-25-gps-1.md
@@ -106,10 +106,10 @@ Aktivieren des Spurenprotokolls
 
     ![Protokoll aktivieren][]
 
--   Wenn du das Spurenprotokoll löschen möchtest um frühere Aufzeichnungen zu entfernen, nutze den Joystick um "Clear" auszuwählen und drücke den Joystick-Knopf. Die obere Leiste sollte "0%" anzeigen.
--   Um das Protokoll zu aktivieren, wähle mit dem Joystick "On" aus und drücke den Joystick-Knopf. Jetzt zichnet das GPS-Gerät deinen Weg auf.
--   In der Option "Set up" kannst du außerdem auch Zeit- oder Distanzintervalle einstellen. Zeitintervalle sagen dem GPS-Gerät, dass es die aktuelle Position in einem bestimmten Intervall aufzeichnen soll. Wenn du eine Speicherkarte in deinem Gerät verwendest, macht es Sinn das Zeitintervall auf 1 Sekunde zu stellen. So wird jede Sekunde die aktuelle Position erfasst und du erhälst eine sehr detaillierte GPS-Spur.
--   Drücke den "X"-Knopf um zur Kartenansicht zurück zu kehren. Wenn du dich bewegst wirst du deine aufgezeichnete Spur als eine Reihe von Punkten angezeigt bekommen.
+-   Wenn Sie das Spurenprotokoll löschen möchten um frühere Aufzeichnungen zu entfernen, wählen Sie "Clear" mit dem Joystick aus und drücken den Joystick-Knopf. Die obere Leiste sollte "0%" anzeigen.
+-   Um das Protokoll zu aktivieren, wählen Sie mit dem Joystick "On" aus und drücken den Joystick-Knopf. Jetzt zeichnet das GPS-Gerät Ihren Weg auf.
+-   In der Option "Set up" können Sie außerdem auch Zeit- oder Distanzintervalle einstellen. Zeitintervalle sagen dem GPS-Gerät, dass es die aktuelle Position in einem bestimmten Intervall aufzeichnen soll. Wenn Sie eine Speicherkarte in Ihrem Gerät verwenden, macht es Sinn, das Zeitintervall auf 1 Sekunde zu stellen. So wird jede Sekunde die aktuelle Position erfasst und Sie erhalten eine sehr detaillierte GPS-Spur.
+-   Drücken Sie den "X"-Knopf um zur Kartenansicht zurückzukehren. Wenn Sie sich bewegen bekommen Sie Ihre aufgezeichnete Spur als eine Reihe von Punkten angezeigt.
 
 
 Wegpunkte und GPS-Spuren auf den Computer kopieren
@@ -117,66 +117,55 @@ Wegpunkte und GPS-Spuren auf den Computer kopieren
 
 ### GPS-Gerät mit dem Computer verbinden
 
--   Ween du mit dem Kartieren fertig bist, möchtest du sicher die Wegpunkte und GPS-Spuren auf deinen Computer kopieren damit du sie in JOSM öffnen kannst. Als erstes solltest du das Spurenprotokoll auf deinem GPS-Gerät wie oben beschrieben deaktivieren, sofern du es noch nicht getan hast. 
--   Verbinde das GPS-Gerät mit dem Computer. Ein Ende des Kabels wird in den USB-Anschluss deines Computers gesteckt, das andere kommt an die Rückseite des GPS-Geräts, unter die obere Gummiabdeckung. Das GPS-Gerät muss eingeschaltet sein, um die Wegpunkte und Spuren zu kopieren.
+-   Wenn Sie mit dem Kartieren fertig sind, möchten Sie sicher die Wegpunkte und GPS-Spuren auf Ihren Computer kopieren damit Sie sie in JOSM öffnen können. Als erstes sollten Sie das Spurenprotokoll auf dem GPS-Gerät wie oben beschrieben deaktivieren sofern noch nicht geschehen. 
+-   Verbinden Sie das GPS-Gerät mit dem Computer. Ein Ende des Kabels wird in den USB-Anschluss des Computers gesteckt, das andere kommt an die Rückseite des GPS-Geräts, unter die obere Gummiabdeckung. Das GPS-Gerät muss eingeschaltet sein, um die Wegpunkte und Spuren zu kopieren.
  
 
 ### GPS-Treiber installieren
 
--   Es kann sein, dass du zunächst noch GPS-Treiber auf deinem Computer installieren musst, damit das GPS-Gerät erkannt wird.
--   Die entsprechende Datei mit dem Namen "USBDrivers\_23.exe" kannst du unter [http://www8.garmin.com/support/download\_details.jsp?id=591](http://www8.garmin.com/support/download_details.jsp?id=591) herunterladen. Öffne die URL in deinem Internetbrowser und drücke auf "Download". Öffne die Datei um die Treiber zu installieren.
-
-
-### Hole dir das GPSBabel Setup-Programm
--   GPSBabel ist ein Programm, welches und ermöglicht Daten vom GPS-Gerät zu kopieren. Falls du eine Kopie von GPSBabel auf CD oder auf einem USB-Stick hast, mache direkt mit dem nächsten Abschnitt weiter.
--   Wenn du GPSBabel noch nicht besitzt, öffne [www.gpsbabel.org](www.gpsbabel.org) in deinem Web-Browser und klicke auf "Downloads" oben auf der Seite.
--   Scrolle nach unten um verschiedene Downloads für die unterschiedlichen Betriebssysteme zu finden. Der oberste Download ist für Computer die unter Windows laufen, der mittlere für Apple-Computer mit Mac OSX und der unterste für Linux-Rechner. Klicke auf den jeweligen Button um die passende Datei herunter zu laden.
+-   Es kann sein, dass Sie zunächst noch GPS-Treiber auf dem Computer installieren müssen, damit das GPS-Gerät erkannt wird.
+-   Passende Treiber finden sich auf der  [Garmin-Webseite](http://www8.garmin.com/support/download_details.jsp?id=591). Laden Sie den Treiber herunter und  öffnen Sie die Datei zur Installation.
 
 
 ### GPSBabel installieren
--   Öffne die gerade heruntergeladene Datei mit einem Doppelklick.
--   Klicke auf "Next".
--   Klicke auf "I accept" und "Next".
--   Drücke weiter auf "Next" bis das Programm anfängt zu installieren.
--   Wenn das Programm fertig installiert ist, klicker auf "Finish" um GPSBabel zu starten.
+-   GPSBabel ist ein Programm, welches es ermöglicht, Daten vom GPS-Gerät zu kopieren. Falls Sie GPSBabel auf CD oder auf einem USB-Stick haben, machen Sie direkt mit dem nächsten Abschnitt weiter.
+-   Wenn Sie GPSBabel noch nicht besitzen, laden Sie es [von der Webseite](www.gpsbabel.org) herunter.
+-   Scrollen Sie nach unten um verschiedene Downloads für die unterschiedlichen Betriebssysteme zu finden. Der oberste Download ist für Computer die unter Windows laufen, der mittlere für Apple-Computer mit Mac OSX und der unterste für Linux-Rechner.
+-   Öffnen Sie die gerade heruntergeladene Datei mit einem Doppelklick.
+-   Klicken Sie auf "Next".
+-   Klicken Sie auf "I accept" und "Next".
+-   Drücken Sie weiter auf "Next" bis das Programm anfängt zu installieren.
+-   Wenn das Programm fertig installiert ist, klicken Sie auf "Finish" um GPSBabel zu starten.
 
     ![GPSBabel Programmoberfläche][]
 
 ### Spuren und Wegpunkte kopieren
 
--   Klicke auf den Kreis neben dem Wort "Device" am oberen Fensterrand.
--   In dem Auswahlmenü "Format" wählst du "Garmin serial/USB
-    protocol" aus.
--   In dem Auswahlmenü in der Mitte des Fensters (unter "Output"), wähle "GPX XML" aus.
+-   Klicken Sie auf den Kreis neben dem Wort "Device" am oberen Fensterrand.
+-   In dem Auswahlmenü "Format" wählen Sie "Garmin serial/USB protocol" aus.
+-   In dem Auswahlmenü in der Mitte des Fensters (unter "Output") wählen Sie "GPX XML" aus.
 
     ![GPX XML auswählen][]
 
--   Wähle "File Name" und tippe einen Namen für die zu speichernde datei ein. Der Name sollte aus etwas sinnvollem bestehen, etwas was die GPS-daten beschreibt, wie das Datum und der Ort. Beispielsweise: _jakarta-07-07-2011_
--   Stelle sicher, dass das GPS-Gerät mit dem Computer verbunden und eingeschaltet ist.
--   Klicke auf "Apply" in der unteren rechten Ecke in GPSBabel.
--   Wenn alles richtig läuft, siehst du eine Fortschrittsleiste, welche anzeigt, dass Daten von GPS-Gerät übertragen werden. Wenn die Übertragung abgeschlossen ist, sind deine Wegpunkte und Spuren in der Datei gespeichert, die du angegeben hast.
+-   Wählen Sie "File Name" und tippen Sie einen Namen für die zu speichernde datei ein. Der Name sollte aus etwas sinnvollem bestehen, etwas was die GPS-Daten beschreibt, wie das Datum und der Ort. Beispielsweise: _jakarta-07-07-2011_
+-   Stellen Sie sicher, dass das GPS-Gerät mit dem Computer verbunden und eingeschaltet ist.
+-   Klicken Sie auf "Apply" in der unteren rechten Ecke in GPSBabel.
+-   Wenn alles richtig läuft, sehen Sie eine Fortschrittsleiste, welche anzeigt, dass Daten von GPS-Gerät übertragen werden. Wenn die Übertragung abgeschlossen ist, sind die Wegpunkte und Spuren in der Datei gespeichert, die Sie angegeben haben.
 
 
 ### Daten in JOSM öffnen
 
--   Als nächstes öffne JOSM. In dem oberen Menü, wähle "File" und klicke auf "Open..."
--   Wähle die Datei aus, die du mit GPSBabel erzeugt hast und klicke auf "Open".
--   Du solltest jetzt deine Wegpunkte und Spuren in JOSM sehen.
+-   Als nächstes starten Sie JOSM. In dem oberen Menü, wählen Sie "Datei" und klicken auf "Öffnen..."
+-   Wählen Sie die Datei aus, die Sie mit GPSBabel erzeugt haben und klicken Sie auf "Öffnen".
+-   Sie sollten jetzt Ihre Wegpunkte und Spuren in JOSM sehen.
 
     ![GPS Dateien in JOSM geöffnet][]
 
 Zusammenfassung
 -------
 
-Glückwunsch! Du solltest jetzt ein gutes Verständnis davon haben, wie man ein GPS-Gerät benutzt. Falls du es nicht schon längst getan hast, probiere mal aus ein paar Wegpunkte von wichtigen Orten in deiner Umgebung zu speichern. In diesem Kapitel hast du gelernt wie man Wegpunkte und GPS-Spuren in JOSM öffnet. In Kapitel 6 werden wir diese Informationen nutzen um neue Informationen zu OpenStreetMap hinzuzufügen. Im nächsten Kapitel lernen wir Walking Papers kennen, welche ein weiterer Weg sind, Informationen für OpenStreetMap zu sammeln. Mit Hilfe von Walking Papers ist es möglich, nur mit Hilfe von Stift und Papier die Koordinaten von Orten aufzuzeichnen, so wie mit einem GPS-Gerät.
+Glückwunsch! Sie sollten jetzt ein gutes Verständnis davon haben, wie man ein GPS-Gerät benutzt. Falls Sie es nicht schon längst getan haben, probieren Sie mal aus, ein paar Wegpunkte von wichtigen Orten in Ihrer Umgebung zu speichern. In diesem Kapitel haben Sie gelernt wie man Wegpunkte und GPS-Spuren in JOSM öffnet. Später werden wir diese Informationen nutzen, um neue Informationen zu OpenStreetMap hinzuzufügen. 
 
-Nächste Schritte
-----------------
-
-Unter diesen Links gibt es nähere Informationen zu:  
-
-*  [Field Papers](/de/beginner/field-papers/)  
-*  [Editieren mit JOSM](/de/beginner/editing-with-josm/)  
 
 
 [Google Earth, Anzeige der Koordinaten von Lombok, Indonesia]: /images/mobile-mapping/google-earth-lombok.png

--- a/_posts/de/mobile-mapping/0900-12-25-gps-1.md
+++ b/_posts/de/mobile-mapping/0900-12-25-gps-1.md
@@ -41,7 +41,7 @@ Das GPS-Gerät in Betrieb nehmen
 Bevor Sie Ihr GPS-Gerät in Betrieb nehmen, gehen Sie nach draußen an einen Ort wo Sie unter freiem Himmel stehen. 
 Da das GPS-Gerät Ihre Position aus von Satelliten empfangenen Daten bestimmt, funktioniert es nicht innerhalb von Gebäuden.
 
-Auf der rechten Seite des Geräts ist der Einschaltknopf, drücken und halten Sie ihn. Das Gerät startet und zeigt als erstes die Ansicht der Satelliten. Es sollte in etwa so aussehen wie auf dem Screenshot unten. Das GPS-Gerät sucht nach verfügbaren Satelliten-Signalen und sobald es sich mit drei oder mehr Satelliten verbunden hat, kann die Position bestimmt werden.
+Auf der rechten Seite des Geräts ist der untere der beiden Knöpfe der Einschaltknopf, drücken und halten Sie ihn. Das Gerät startet und zeigt als erstes die Ansicht der Satelliten. Es sollte in etwa so aussehen wie auf dem Screenshot unten. Das GPS-Gerät sucht nach verfügbaren Satelliten-Signalen und sobald es sich mit drei oder mehr Satelliten verbunden hat, kann die Position bestimmt werden.
 
 ![GPS Positionsbestimmung][]
 
@@ -81,7 +81,7 @@ Außerdem kann Ihr GPS-Gerät sogenannte Spuren aufzeichnen. Während ein Wegpun
 Eine Position speichern
 -----------------------------------
 
--   Um Ihre aktuelle Position als einen Wegpunkt zu speichern, drücken Sie den "X"-Knopf solange, bis Sie in das Hauptmenü gelangen. Mit Hilfe des Joysticks auf der Vorderseite des Geräts können Sie den Menüpunkt "Mark" auswählen und anschließend den Joystick-Knopf nach unten drücken, um die "Wegpunkt speichern"-Ansicht aufzurufen.
+-   Um Ihre aktuelle Position als einen Wegpunkt zu speichern, drücken Sie den "X"-Knopf solange, bis Sie in das Hauptmenü gelangen. Mit Hilfe des Joysticks auf der Vorderseite des Geräts können Sie den Menüpunkt "Mark" auswählen und anschließend den Joystick-Knopf nach unten drücken, um die "Wegpunkt speichern"-Ansicht aufzurufen. Alternativ können Sie auch den Joystick länger gedrückt halten, bis die "Wegpunkt speichern"-Ansicht erscheint.
 
     ![Position 1 speichern][]
 
@@ -102,13 +102,13 @@ Aktivieren des Spurenprotokolls
 ---------------------
 
 -   Wir haben schon gesehen, wie man Wegpunkte speichert. Kümmern wir uns also jetzt darum, wie man das Spurenprotokoll aktiviert. Dann zeichnet das GPS-Gerät automatisch Ihren zurückgelegten Weg auf. Es ist eine gute Idee, das Protokoll zu aktivieren, wenn man mit der Kartierung anfängst und es zu deaktivieren, wenn man fertig ist. Sie können anschliessend Ihre GPS-Spur am Computer anschauen. Wenn Sie den Verlauf einer Straße kartieren, speichern Sie am besten zu Beginn und Ende der Straße jeweils einen Wegpunkt. Schreiben Sie sich noch den Namen, die Art der Stra0e und andere nützliche Informationen auf.
--   Um das Spurenprotokoll zu aktivieren, drücken Sie den "X"-Knopf sooft, bis Sie zur Ansicht "Track Log" kommen.
+-   Um das Spurenprotokoll zu aktivieren, wählen Sie im Hauptmenü mit dem Joystick die Ansicht "Track Log" aus.
 
     ![Protokoll aktivieren][]
 
--   Wenn Sie das Spurenprotokoll löschen möchten um frühere Aufzeichnungen zu entfernen, wählen Sie "Clear" mit dem Joystick aus und drücken den Joystick-Knopf. Die obere Leiste sollte "0%" anzeigen.
--   Um das Protokoll zu aktivieren, wählen Sie mit dem Joystick "On" aus und drücken den Joystick-Knopf. Jetzt zeichnet das GPS-Gerät Ihren Weg auf.
--   In der Option "Set up" können Sie außerdem auch Zeit- oder Distanzintervalle einstellen. Zeitintervalle sagen dem GPS-Gerät, dass es die aktuelle Position in einem bestimmten Intervall aufzeichnen soll. Wenn Sie eine Speicherkarte in Ihrem Gerät verwenden, macht es Sinn, das Zeitintervall auf 1 Sekunde zu stellen. So wird jede Sekunde die aktuelle Position erfasst und Sie erhalten eine sehr detaillierte GPS-Spur.
+-   Wenn Sie das Spurenprotokoll löschen möchten um frühere Aufzeichnungen zu entfernen, wählen Sie "Löschen" mit dem Joystick aus und drücken den Joystick-Knopf. Die obere Leiste sollte "0%" anzeigen.
+-   Um das Protokoll zu aktivieren, wählen Sie mit dem Joystick "An" aus und drücken den Joystick-Knopf. Jetzt zeichnet das GPS-Gerät Ihren Weg auf.
+-   In der Option "Einstellung" können Sie außerdem auch Zeit- oder Distanzintervalle einstellen. Zeitintervalle sagen dem GPS-Gerät, dass es die aktuelle Position in einem bestimmten Intervall aufzeichnen soll. Wenn Sie eine Speicherkarte in Ihrem Gerät verwenden, macht es Sinn, das Zeitintervall auf 1 Sekunde zu stellen. So wird jede Sekunde die aktuelle Position erfasst und Sie erhalten eine sehr detaillierte GPS-Spur.
 -   Drücken Sie den "X"-Knopf um zur Kartenansicht zurückzukehren. Wenn Sie sich bewegen bekommen Sie Ihre aufgezeichnete Spur als eine Reihe von Punkten angezeigt.
 
 
@@ -129,7 +129,7 @@ Wegpunkte und GPS-Spuren auf den Computer kopieren
 
 ### GPSBabel installieren
 -   GPSBabel ist ein Programm, welches es ermöglicht, Daten vom GPS-Gerät zu kopieren. Falls Sie GPSBabel auf CD oder auf einem USB-Stick haben, machen Sie direkt mit dem nächsten Abschnitt weiter.
--   Wenn Sie GPSBabel noch nicht besitzen, laden Sie es [von der Webseite](www.gpsbabel.org) herunter.
+-   Wenn Sie GPSBabel noch nicht besitzen, laden Sie es [von der Webseite](http://www.gpsbabel.org) herunter.
 -   Scrollen Sie nach unten um verschiedene Downloads für die unterschiedlichen Betriebssysteme zu finden. Der oberste Download ist für Computer die unter Windows laufen, der mittlere für Apple-Computer mit Mac OSX und der unterste für Linux-Rechner.
 -   Öffnen Sie die gerade heruntergeladene Datei mit einem Doppelklick.
 -   Klicken Sie auf "Next".

--- a/_posts/de/mobile-mapping/0900-12-25-gps-1.md
+++ b/_posts/de/mobile-mapping/0900-12-25-gps-1.md
@@ -9,84 +9,100 @@ category: mobile-mapping
 Kartierung mit einem GPS-Gerät
 ====================
 
-In diesem Kapitel werden wir herausfinden was ein GPS-Gerät ist und wie es funktioniert. Du wirst lernen wie man ein GPS-Gerät benutzt und wie du mit dessen Hilfe Karten erstellen kannst. Das in diesem Kapitel vorgestellte und verwendete GPS-Gerät ist das Garmin eTrex HCx, welches weit verbreitet ist und zum Kartieren eingesetzt wird. Es gibt noch viele andere Hersteller und Modelle, welche alle den gleichen Zweck verfolgen. Falls du also ein anderes GPS-Gerät verwendest, keine Sorge - die grundsätzlichen Funktionen sind die gleichen.
+Eine der wesentlichen Aufgaben bei der Kartierung ist die Bearbeitung der Karte, also das Eintragen von Informationen.
+Davor müssen diese Informationen aber erst einmal beschafft werden, z.B. in dem man ein Gebiet selbst durchstreift.
+
+In diesem Kapitel werden wir herausfinden was ein GPS-Gerät ist und wie es funktioniert. Sie werden lernen wie man ein GPS-Gerät benutzt und wie Sie mit dessen Hilfe Karten erstellen können. 
+
+Das in diesem Kapitel vorgestellte und verwendete GPS-Gerät ist das Garmin eTrex Vista HCx, welches weit verbreitet
+ist und zum Kartieren eingesetzt wird. Es gibt noch viele andere Hersteller und Modelle, welche alle den gleichen 
+Zweck verfolgen. Falls Sie also ein anderes GPS-Gerät verwenden, keine Sorge - die grundsätzlichen Funktionen sind 
+die gleichen.
 
 
 Was ist ein GPS-Gerät?
 --------------
 
-Ein GPS-Gerät ähnelt einem Mobiltelefon, allerdings empfängt es keine Signale aus dem Mobilfunktnetz. Vielmehr kann ein GPS-Gerät Signale von Satelliten empfangen welche um die Erde kreisen. Dadurch ist es in der Lage deine exakte Position auf der Erde zu bestimmen. Die Position wird in Koordinaten erfasst, welche aus zwei langen zahlen bestehen. Die erste Zahl beschreibt, wie weit westlich oder östlich du dich (vom Nullmeridian) aufhälst - man nennt das Längengrad - und die zweite Zahl gibt an wie weit nördlich oder südlich (vom Äquator) du bist - dies nennt man Breitengrad. Jeder Ort auf der Erde verfügt über einzigartige geografische Koordinaten.
+Ein GPS-Gerät ähnelt einem Mobiltelefon, allerdings empfängt es keine Signale aus dem Mobilfunktnetz. Vielmehr kann
+ein GPS-Gerät Signale von Satelliten empfangen die um die Erde kreisen. Dadurch ist es in der Lage, Ihre exakte 
+Position auf der Erde zu bestimmen. Die Position wird in zwei Zahlen, den Koordinaten, erfasst. 
+Die erste Zahl beschreibt, wie weit westlich oder östlich Sie sich vom Nullmeridian aufhalten - man nennt das 
+Längengrad - und die zweite Zahl gibt an, wie weit nördlich oder südlich vom Äquator Sie sind - dies nennt man 
+Breitengrad. Jeder Ort auf der Erde verfügt über einzigartige geografische Koordinaten.
 Zum Beispiel: -8.639298 (südliche) Breite, 116.311607 (östliche) Länge ist ein Ort in Lombok, Indonesien.
 
 ![Google Earth, Anzeige der Koordinaten von Lombok, Indonesia][]
 
-![Garmin eTrex Vista HCx][]
-
 Das GPS-Gerät in Betrieb nehmen
 ---------------
 
-Bevor du dein GPS-Gerät in Betrieb nimmst, gehe nach draußen an einen Ort wo du unter freiem Himmel stehst. Da das GPS-Signal mithilfe von Satelliten bestimmt wird, funktioniert es nicht innerhalb von Gebäuden.
+![Garmin eTrex Vista HCx][]
 
-Auf der rechten Seite des Geräts ist der Einschaltknopf, drücke und halte ihn. Das Gerät startet und wird als erstes die Ansicht der Satelliten laden. Es sollte in etwa so aussehen wie auf dem Screenshot unten. Das GPS-Gerät sucht nach einem verfügbaren Satelliten-Signal und sobald es sich mit drei oder mehr Satelliten verbunden hat, kann die Position bestimmt werden.
+Bevor Sie Ihr GPS-Gerät in Betrieb nehmen, gehen Sie nach draußen an einen Ort wo Sie unter freiem Himmel stehen. 
+Da das GPS-Gerät Ihre Position aus von Satelliten empfangenen Daten bestimmt, funktioniert es nicht innerhalb von Gebäuden.
+
+Auf der rechten Seite des Geräts ist der Einschaltknopf, drücken und halten Sie ihn. Das Gerät startet und zeigt als erstes die Ansicht der Satelliten. Es sollte in etwa so aussehen wie auf dem Screenshot unten. Das GPS-Gerät sucht nach verfügbaren Satelliten-Signalen und sobald es sich mit drei oder mehr Satelliten verbunden hat, kann die Position bestimmt werden.
 
 ![GPS Positionsbestimmung][]
 
-Sobald deine Position bestimmt wurde, wird die Satelliten-Ansicht geschlossen und das Hauptmenü geöffnet.
+Sobald Ihre Position bestimmt wurde, wird die Satelliten-Ansicht geschlossen und das Hauptmenü geöffnet.
 
 ![GPS Hauptmenü][]
 
 Mit dem GPS-Gerät navigieren
 ----------------
 
--   Das GPS-Gerät verfügt über verschiedene Ansichten, welche verschiedene Funktionen beherbergen. Um zwischen den einzelnen Anischten zu wechseln, drücke auf den Knopf "X", welcher sich direkt über dem Einschaltknopf an der rechten Seite des Geräts befindet. Dieser Knopf ist auch gleichzeitig ein "Zurück"-Knopf, falls du aus Versehen auf irgendetwas gedrückt hast und die Aktion abbrechen möchtest, drück auf den "X"-Knopf.
--   Mit Hilfe des "X"-Knpofes kannst du durch die einzelnen Ansichten wechseln, was ungefähr so aussieht:
+-   Das GPS-Gerät verfügt über verschiedene Ansichten, die verschiedene Funktionen beherbergen. Um zwischen den einzelnen Anischten zu wechseln, drücken SIe auf den Knopf "X" direkt über dem Einschaltknopf an der rechten Seite des Geräts. Dieser Knopf ist auch gleichzeitig ein "Zurück"-Knopf. Falls Sie aus Versehen auf irgendetwas gedrückt haben und die Aktion abbrechen möchten, drücken Sie auf den "X"-Knopf.
+-   Mit Hilfe des "X"-Knopfes können Sie durch die einzelnen Ansichten wechseln, was ungefähr so aussieht:
 
     ![GPS alle][]
 
--   Wenn du zur Satelliten-Ansicht zurückkehrst, kannst du sehen, dass das Gerät mit mindestens drei Satelliten verbunden ist. In der oberen linken Ecke sind deine Koordinaten zu sehen, in Breiten- und Längengraden.
+-   Wenn Sie zur Satelliten-Ansicht zurückkehren, sehen Sie, dass das Gerät mit mindestens drei Satelliten verbunden ist. In der oberen linken Ecke sind Ihre Koordinaten zu sehen, der Breiten- und Längengrad.
 
-> Um OSM zu deinem GPS-Gerät hinzuzufügen, lade die neuesten Daten von [http://labs.geofabrik.de/haiti/latest.garmin-gmapsupp.zip](http://labs.geofabrik.de/haiti/latest.garmin-gmapsupp.zip) herunter.
-> Entpacke “latest.garmin-gmapsupp.zip” und speichere die Datei “gmapsupp.img” vorübergehend in einen Ordner. Nachdem du dein GPS-Gerät eingeschaltet und mit dem Computer verbunden hast, sollte das Gerät als USB-Laufwerk sichtbar sein. Erstelle einen neuen Ordner mit dem Namen "Garmin" im Hauptverzeichnis des USB-Laufwerks.
-> Kopiere die Datei "gmapsupp.img" in den neu erstellten "Garmin"-Ordner.
-> Als letztes starte das GPS-Gerät neu. Die extrahierte OSM-Karte sollte zu deinem Gerät hinzugefügt werden.
-
-- Wechsle zur Kartenansicht und du kannst eine Karte mit deiner aktuellen Position sehen. Wenn du die OSM-Karte hinzugefügt hast, wirst du wahrscheinlich auch Straßen und Orte sehen. Wenn nicht, könnte die Karte ziemlich leer aussehen. Mit den "Hoch"- und "Runter"-Knöpfen an der linken Seite des Gerätes kannst du die Karte vergrößern und verkleinern.
+- Wechseln Sie zur Kartenansicht und Sie sehen eine Karte mit Ihrer aktuellen Position. Wenn Sie eine OSM-Karte hinzugefügt haben, sehen Sie wahrscheinlich auch Straßen und Orte. Wenn nicht, könnte die Karte ziemlich leer aussehen. Mit den "Hoch"- und "Runter"-Pfeilknöpfen an der linken Seite des Gerätes können Sie die Karte vergrößern und verkleinern.
+- Nähere Informationen, woher man OpenStreetMap-Karten für Garmin-Geräte bekommt und wie man sie installiert, finden
+  Sie [im OSM-Wiki](http://wiki.openstreetmap.org/wiki/DE:OSM_Map_On_Garmin/Download)
 
 
 Spuren und Wegpunkte
 --------------------
 
-Dein GPS-Gerät nimmt zwei Arten von Informationen auf, welche nützlich sind zum Speichern von Koordinaten und Erstellen von Karten. Zum einen kann die aktuelle Position in den Speicher des Geräts geschrieben werden. Wenn du eine Position speicherst werden die Koordinaten mit einem Namen versehen. der erste punkt wird beispielswesie 001 genannt, der zweite 002, und so weiter.
+Ihr GPS-Gerät nimmt zwei Arten von Informationen auf, die für die Erstellung einer Karte interessant sind. Zum einen kann die aktuelle Position in den Speicher des Geräts geschrieben werden. Wenn Sie eine Position speichern, werden die Koordinaten mit einem Namen versehen. Der erste Punkt wird beispielsweise 001 genannt, der zweite 002, und so weiter.
 
 
-> Falls dein GPS-Gerät nicht mit 001 anfängt und du die vorherigen Punkte löschen möchtest, wähle das "Finden"-Icon im Hauptmenü aus. Wähle "Wegpunkte" und dann den Knopf für das Untermenü auf der rechten Seite um das Wegpunkte-Untermenü anzuzeigen. Wähle unten "Löschen", dann "Alle Symbole" und drücke zum Bestätigen "Ja".
+> Falls Ihr GPS-Gerät nicht mit 001 anfängt und Sie die vorherigen Punkte löschen möchten, wählen Sie das "Finden"-Icon im Hauptmenü aus. Wählen Sie "Wegpunkte" und dann den Knopf für das Untermenü auf der rechten Seite, um das Wegpunkte-Untermenü anzuzeigen. Wählen Sie unten "Löschen", dann "Alle Symbole" und drücken Sie zum Bestätigen "Ja".
 
-Wenn du eine Position speicherst, kannst du dir die Nummer auf einem Stück Papier notieren, zusammen mit einer Notiz was dort zu finden ist und allen möglichen Attributen und Hinweisen die du wissen möchtest. Gespeicherte Positionen auf deinem GPS-Gerät werden Wegpunkte genannt.
+Wenn Sie eine Position speichern, können Sie sich die Nummer aufschreiben zusammen mit einer Notiz, was dort zu finden ist und allen möglichen Attributen und Hinweisen, die für die Karte von Interesse sind. Gespeicherte Positionen auf dem GPS-Gerät werden Wegpunkte genannt.
 
-Außerdem kann dein GPS-Gerät sogenannte Spuren aufzeichnen. Während ein Wegpunkt nur eine bestimmt Position speichert, kann eine GPS-Spur eine ganze Reihe an Positionen, an denen du dich aufhälst, aufzeichnen. Zum Beispiel kann das Gerät jede Sekunde eine Position aufnehmen, oder jeden Meter den du dich bewegst. Das Resultat ist eine Reihe von Punkten, die eine Spur darstellen, wo du gewesen bist. So eine Spur ist nützlich um Objekte zu erfassen, welche durch Linen oder Formen dargestellt werden, beispielsweise Straßen oder Spielfelder.
+Außerdem kann Ihr GPS-Gerät sogenannte Spuren aufzeichnen. Während ein Wegpunkt nur eine bestimmte Position speichert, enthält eine GPS-Spur eine ganze Reihe von Positionen, die z.B. einer Fahrt- oder Wanderstrecke entsprechen. Zum Beispiel kann das Gerät jede Sekunde eine Position aufnehmen, oder jeden Meter den Sie sich bewegen. Das Resultat ist eine Reihe von Punkten, die eine Spur darstellen, wo Sie gewesen sind. So eine Spur ist nützlich um Objekte zu erfassen, welche durch Linien oder Formen dargestellt werden, beispielsweise Straßen oder Begrenzungen von Feldern.
 
 ![GPS Spur][]
 
-Deine Position speichern
+Eine Position speichern
 -----------------------------------
 
--   Um deine aktuelle Position als einen Wegpunkt zu speichern, drücke den "X"-Knopf solange, bis du in das Hauptmenü gelangst. Mit Hilfe des Joysticks kannst du den Menüpunkt "Mark" auswählen und anschließend den Joystick-Knopf runterdrücken um die "Wegpunkt speichern"-Ansicht aufzurufen.
+-   Um Ihre aktuelle Position als einen Wegpunkt zu speichern, drücken Sie den "X"-Knopf solange, bis Sie in das Hauptmenü gelangen. Mit Hilfe des Joysticks auf der Vorderseite des Geräts können Sie den Menüpunkt "Mark" auswählen und anschließend den Joystick-Knopf nach unten drücken, um die "Wegpunkt speichern"-Ansicht aufzurufen.
 
     ![Position 1 speichern][]
-    ![Position 2 speichern][]
+
+<!-- no need to bother users with this right here - stored tracks and waypoints are always in lat/lon format and based on WGS84 irrespective of user interface settings
 
 > Falls du mehrere GPS-Geräte verwendest, ist es wichtig sicherzustellen, dass alle Geräte auf das selbe Positionsformat eingestellt sind. Um dies zu überprüfen, wähle das Hauptmenü aus und finde den Unterpunkt "Set up Menu". Klicke auf "Einheiten" und stelle sicher, dass Folgendes eingestellt ist: Positionsformat auf Dezimalgrad (hddd.ddddd°), das Kartendatum auf WGS84 und die Distanzgeschwindigkeit, Erhebung und Tiefe auf Meter.
+-->
 
--   Du kannst in dieser Ansicht gewisse Informationen über den Wegpunkt sehen, den du speicherst. Zunächst den Namen, falls dies dein erster Wegpunkt ist, steht dort vermutlich "001". Dies ist die Zahl die du dir zusammen mit Zusatzinformationen auf Papier notieren solltest. Als nächstes wird das Datum und die Uhrzeit angezeigt an dem der Wegpunkt aufgenommen wurde. Darunter stehen die geografischen Koordinaten und die Höhe über dem Meeresspiegel.
--   Nutze den Joystick um den "OK"-Knopf unten in der Ansicht auszuwählen. Drücke den Joystick runter um diesen Wegpunkt zu speichern. Stelle sicher, dass du dir die Nummer des Punktes aufgeschrieben hast, zusammen mit Zusatzinformationen über den Wegpunkt.
--   Drücke den "X"-Knopf, um wieder zur Kartenansicht zu gelangen. Dein Wegpunkt sollte nun auf der Karte sichtbar sein.
+-   Sie können in dieser Ansicht gewisse Informationen über den Wegpunkt sehen, den Sie speichern. Zunächst den Namen, beim ersten Wegpunkt steht dort vermutlich "001". Sie sollten sich diese Zahl zusammen mit Zusatzinformationen aufschreiben. Als nächstes wird das Datum und die Uhrzeit angezeigt, an dem der Wegpunkt aufgenommen wurde. Darunter stehen die geografischen Koordinaten und die Höhe über dem Meeresspiegel.
+-   Wählen Sie mit dem Joystick den "OK"-Knopf unten in der Ansicht aus. Drücken Sie auf den Joystick um diesen Wegpunkt zu speichern. Denken Sie daran, sich den Namen und weitere Informationen aufzuschreiben.
+
+    ![Position 2 speichern][]
+
+-   Drücken SIe den "X"-Knopf, um wieder zur Kartenansicht zu gelangen. Ihr Wegpunkt sollte nun auf der Karte sichtbar sein.
 
 
 Aktivieren des Spurenprotokolls
 ---------------------
 
--   Nun, da wir wissen, wie man Wegpunkte speichert, ist es sinnvoll zu lernen, wie man das Spurenprotokoll aktiviert. Wenn das Spurenprotokoll aktiviert ist, zeichnet das GPS-Gerät automatisch deinen zurück gelegten Weg auf. Es ist üblich das Protokoll zu aktivieren, wenn du mit der Kartierung anfängst und es zu deaktivieren wenn du fertig bist. So kannst du anschliessend deine GPS-Spur am Computer anschauen. Wenn du den Verlauf einer Straße kartierst, ist eine gute Idee, zu Beginn und Ende jeweils einen Wegpunkt zu speichern. So kannst du den Namen und andere nützliche Informationen über die Straße in deinem Notizbuch aufschreiben.
--   Um das Spurenprotokoll zu aktivieren, drücke den "X"-Knopf solange, bis du zur Ansicht "Track Log" kommst.
+-   Wir haben schon gesehen, wie man Wegpunkte speichert. Kümmern wir uns also jetzt darum, wie man das Spurenprotokoll aktiviert. Dann zeichnet das GPS-Gerät automatisch Ihren zurückgelegten Weg auf. Es ist eine gute Idee, das Protokoll zu aktivieren, wenn man mit der Kartierung anfängst und es zu deaktivieren, wenn man fertig ist. Sie können anschliessend Ihre GPS-Spur am Computer anschauen. Wenn Sie den Verlauf einer Straße kartieren, speichern Sie am besten zu Beginn und Ende der Straße jeweils einen Wegpunkt. Schreiben Sie sich noch den Namen, die Art der Stra0e und andere nützliche Informationen auf.
+-   Um das Spurenprotokoll zu aktivieren, drücken Sie den "X"-Knopf sooft, bis Sie zur Ansicht "Track Log" kommen.
 
     ![Protokoll aktivieren][]
 

--- a/_posts/de/mobile-mapping/0900-12-30-mobile_mapping.md
+++ b/_posts/de/mobile-mapping/0900-12-30-mobile_mapping.md
@@ -20,8 +20,8 @@ Es gibt allerdings große Unterschiede in der Genauigkeit und Leistungsfähigkei
 
 Geräte mit GPS-Empfängern können autonom arbeiten, auch außerhalb der Reichweite von Mobilfunk- und 
 Internet-Verbindungen. Geräte mit der Bezeichnung "“A-GPS only” (Assisted GPS) erfordern eine Datenverbindung 
-über ein Mobilfunknetz um richtig arbeiten zu können. A-GPS-Daten können auch eigenständigen GPS-Chips zu einer
-besseren Leistung verhelfen, indem sie Daten vorgehalten werden.
+über ein Mobilfunknetz um richtig arbeiten zu können. A-GPS-Daten können auch eigenständigen GPS-Empfängern zu einer
+besseren Leistung verhelfen, da die ungefähre Position schneller über das Funknetz festgestellt werden kann.
 
 In den meisten Fällen brauchen wir ein Smartphone mit einem eigenen GPS-Empfänger. Überprüfen Sie, ob Ihr Gerät
 diesen Spezifikationen entspricht oder ob es sich lediglich um ein A-GPS-Gerät handelt.
@@ -38,7 +38,7 @@ Im Hinblick auf die Eignung für OpenStreetMap kommt es auf diese Eigenschaften 
 -   Georeferenzierung von Multimedia-Daten (Anmerkungen, Fotos, Videos)
 -   ständige Weiterentwicklung
 
-Probieren Sie mehrere zu Ihrem Gerät kompatible Anwendung aus, um sich mit der Benutzeroberfläche
+Probieren Sie mehrere zu Ihrem Gerät kompatible Anwendungen aus, um sich mit der Benutzeroberfläche
 vertraut zu machen und herausfinden, welche davon Ihren Vorlieben und Vorgehensweisen am besten entspricht.
 
 <!-- Commenting for now since tables doesn't look very nice!

--- a/_posts/de/mobile-mapping/0900-12-30-mobile_mapping.md
+++ b/_posts/de/mobile-mapping/0900-12-30-mobile_mapping.md
@@ -2,13 +2,13 @@
 layout: doc
 permalink: /de/mobile-mapping/
 lang: de
-title: Kartierung mit Smartphone, GPS oder Notizzettel
+title: Kartierung mit Smartphone, GPS oder Papier
 category: mobile-mapping
 cover: yes
 nosearch: true
 ---
 
-Kartierung mit Smartphone, GPS oder Notizzettel
+Kartierung mit Smartphone, GPS oder Papier
 ===============================================
 
 Mehr und mehr Smartphones verfügen heutzutage über einen Chip, der die Signale von Satelliten-Navigationssystemen

--- a/_posts/de/mobile-mapping/0900-12-30-mobile_mapping.md
+++ b/_posts/de/mobile-mapping/0900-12-30-mobile_mapping.md
@@ -2,53 +2,44 @@
 layout: doc
 permalink: /de/mobile-mapping/
 lang: de
-title: Mapping with a SmartPhone, GPS or Paper
+title: Kartierung mit Smartphone, GPS oder Notizzettel
 category: mobile-mapping
 cover: yes
 nosearch: true
 ---
 
-Mapping with a Smartphone, GPS or Paper
-=============================
+Kartierung mit Smartphone, GPS oder Notizzettel
+===============================================
 
-More and more smartphones today include a radio chip that allows them to
-receive signals from satellite navigation systems and determine their
-location. The most common chips receive signals from the U.S. GPS
-frequencies, while higher end models may include chips that can read
-frequencies from the Russian GLONASS satellites at the same time.
+Mehr und mehr Smartphones verfügen heutzutage über einen Chip, der die Signale von Satelliten-Navigationssystemen
+empfangen und daraus die Position bestimmen kann. Meist handelt es sich dabei um die Satelliten des von den USA
+betriebenen GPS-Systems. Geräte aus dem oberen Preissegment empfangen teilweise zusätzlich
+die Frequenzen der russischen GLONASS-Satelliten.
 
-The quality of the chips used in smartphones may vary, and data accuracy
-and performance could vary as well.
+Es gibt allerdings große Unterschiede in der Genauigkeit und Leistungsfähigkeit der eingesetzten Chips.
 
-Devices with GPS chips can work autonomously, off the grid, and without
-an Internet connection, while devices marked with “A-GPS only” (Assisted
-GPS) require a network data connection (and a mobile signal from a
-telecommunications company) to work correctly. A-GPS data can help
-autonomous GPS chips perform better by pre-caching data for better
-performance.
+Geräte mit GPS-Empfängern können autonom arbeiten, auch außerhalb der Reichweite von Mobilfunk- und 
+Internet-Verbindungen. Geräte mit der Bezeichnung "“A-GPS only” (Assisted GPS) erfordern eine Datenverbindung 
+über ein Mobilfunknetz um richtig arbeiten zu können. A-GPS-Daten können auch eigenständigen GPS-Chips zu einer
+besseren Leistung verhelfen, indem sie Daten vorgehalten werden.
 
-For most mapping applications to work as expected, the user is assumed
-to have a smartphone with an autonomous GPS chip. Check your device
-specifications to confirm whether your device uses an autonomous chip,
-or is A-GPS only device.
+In den meisten Fällen brauchen wir ein Smartphone mit einem eigenen GPS-Empfänger. Überprüfen Sie, ob Ihr Gerät
+diesen Spezifikationen entspricht oder ob es sich lediglich um ein A-GPS-Gerät handelt.
 
-There are a lot of mapping applications available (for free or paid) for
-most smartphones in the market. Each app has its own advantages and
-disadvantages.
+Es gibt eine ganze Reihe von (sowohl kostenlosen als auch kommerziellen) Kartographie-Anwendungen für die meisten 
+Smartphones. Jede hat ihre Vor- und Nachteile.
 
-In choosing a mapping application for mapping in OpenStreetMap, you need
-to consider the following features.
+Im Hinblick auf die Eignung für OpenStreetMap kommt es auf diese Eigenschaften an:
 
--   Easy to learn; immediately usable
--   With GPX support (create waypoints, customizable log intervals)
--   Allows OSM contribution (add, edit, upload data)
--   Able to load OSM data offline
--   Able to geo-tag multimedia files (notes, photos, videos)
--   In active development
+-   einfach zu bedienen; man kann sofort loslegen
+-   Unterstützung für GPX-Dateien (Anlegen von Wegpunkten, konfigurierbares Speicherintervall)
+-   direkte Anbindung an OSM (Hinzufügen, Bearbeiten, Hochladen von Daten)
+-   Möglichkeit, OSM-Daten vorher auf das Gerät zu laden
+-   Georeferenzierung von Multimedia-Daten (Anmerkungen, Fotos, Videos)
+-   ständige Weiterentwicklung
 
-Try several applications that are compatible with your phone to get
-familiar with the interface and choose the best app based on your
-personal preference and mapping approach.
+Probieren Sie mehrere zu Ihrem Gerät kompatible Anwendung aus, um sich mit der Benutzeroberfläche
+vertraut zu machen und herausfinden, welche davon Ihren Vorlieben und Vorgehensweisen am besten entspricht.
 
 <!-- Commenting for now since tables doesn't look very nice!
 
@@ -70,10 +61,9 @@ O - supported, D - under development, m - mapping, n - navigation, p - POI edito
 
 -->
 
-The next sections will guide you through the installation and use of specific applications
-for you to contribute to OpenStreetMap using your smartphones.
+In den nächsten Abschnitten führen wir Sie durch die Installation und die Bedienung von verschiedenen Anwendungen,
+mit denen Sie von Ihrem Smartphone an OpenStreetMap mitwirken können.
 
->   **Note:** Before proceeding any further, verify that GPS is available and
->   active for the device. In Android, go to **Settings \> Location** and enable it.
->   Remember, GPS doesn’t work inside buildings!
+>   **Achtung:** Bevor Sie weiterlesen, stellen Sie sicher, dass Ihr Gerät über einen GPS-Empfänger verfügt
+>   und dass dieser aktiviert ist. Denken Sie daran, dass GPS nicht innerhalb von Gebäuden funktioniert!
 

--- a/_posts/en/mobile-mapping/0900-12-25-gps.md
+++ b/_posts/en/mobile-mapping/0900-12-25-gps.md
@@ -82,7 +82,7 @@ Navigate the GPS
     Otherwise, the map may look quite blank. Zoom in and out by pressing
     the up and down arrow buttons on the left side of the GPS.
 
-- Further information where to obtain maps for Garmin devices and how to install them can be found 
+- Further information where to obtain OSM maps for Garmin devices and how to install them can be found 
   [in the OSM wiki](http://wiki.openstreetmap.org/wiki/OSM_Map_On_Garmin/Download)
 
 Tracks and Waypoints

--- a/_posts/en/mobile-mapping/0900-12-25-gps.md
+++ b/_posts/en/mobile-mapping/0900-12-25-gps.md
@@ -77,21 +77,13 @@ Navigate the GPS
     connected to three or more satellites. In the upper left corner are
     your coordinates, your latitude and longitude.
 
-<!-- This Note below should be updated for other non-Haiti people, or moved to an advanced section
-
-> To add OSM to your GPS, download the latest data from [http://labs.geofabrik.de/haiti/latest.garmin-gmapsupp.zip](http://labs.geofabrik.de/haiti/latest.garmin-gmapsupp.zip).
-> Unzip “latest.garmin-gmapsupp.zip” and save the “gmapsupp.img” file
-> into a temporary folder. After turning on and connecting your GPS
-> to your computer, create a “Garmin” folder at the root of the USB drive
-> that appeared when you plugged in the GPS. Copy the gmapsupp.img to the
-> “Garmin” folder. Lastly, restart the GPS and the OSM map extracts should
-> be added to your device.
--->
-
 -   Flip to the Map page, and you can see a map of where you are. If you
     have added OSM maps to your GPS, you may see roads and places.
     Otherwise, the map may look quite blank. Zoom in and out by pressing
     the up and down arrow buttons on the left side of the GPS.
+
+- Further information where to obtain maps for Garmin devices and how to install them can be found 
+  [in the OSM wiki](http://wiki.openstreetmap.org/wiki/OSM_Map_On_Garmin/Download)
 
 Tracks and Waypoints
 --------------------
@@ -132,7 +124,8 @@ Save Your Location
 -   To save your current location as a waypoint, click the “X” button
     until your reach the Main Menu. Using the joystick, move it so that
     “Mark” is highlighted on the screen. Push the joystick button down
-    to open the “Save Waypoint” page.
+    to open the “Save Waypoint” page. Alternatively, you may press the
+    the joystick button on any page until the "Save Waypoint" page opens.
 
 ![save location 1][]
 


### PR DESCRIPTION
- translated 0900-12-30-mobile_mapping.md to German
- removed references to GPS document from 0200-12-21-start-josm.md and 0200-12-18-more-about-josm.md
- polished 0900-12-25-gps-1.md: removed lots of typos, made stylistic upgrades, took German Garmin interface into account

Two points worth mentioning which I added in the German version and ported back to the English version:

1. I mentioned a shortcut how to set a waypoint without having to navigate through menus
2. I replaced that funny paragraph on how to install a - meanwhile no longer existing - Haiti map on a Garmin device by a link to the relevant page in the OSM wiki

Another point which appeared only in the German version: the document suggested to make sure that the device is setup to use lat/lon coordinates based on WGS84 in order to make sure GPX files are compatible. I deleted this paragraph because first of all it is technically wrong. GPX is an interchange format where all coordinates refer to that base irrespective of the interface settings. Second, talking about map datums and map grids is a topic of its own.