### PR TITLE
Fixes headers and blockquote formatting, and 2 links

### DIFF
--- a/_posts/bi/osm-data/0600-12-15-getting-data.md
+++ b/_posts/bi/osm-data/0600-12-15-getting-data.md
@@ -14,6 +14,7 @@ yang menyediakan data ekstrak untuk sebuah daerah pilihan Anda.
 
 Mendownload Data Ekstrak
 ------------------------
+
 ### Geofabrik
 [GeoFabrik](http://geofabrik.de) adalah perusahaan yang mengkhususkan diri bekerja
 dengan OpenStreetMap. Mereka menyediakan berbagai ekstrak gratis pada shapefile dan 
@@ -27,21 +28,22 @@ diambil per negara, dan tidak semua negara tersedia.
 shapefile untuk kota diseluruh dunia. Hal ini berguna jika Anda mencari untuk data
 ekstrak suatu kota. Kelemahan situs ini adalah tidak diperbarui secara teratur.
 
->	Ingatlah bahwa fitur dalam OpenStreetMap memiliki jumlah tag "gratis" yang 
->	tidak terbatas, namun shapefile memiliki atribut yang disimpan dalam jumlah 
->	kolom yang terbatas. Hal ini dimaksudkan bahwa ketika data OSM dikonversi
->	ke dalam shapefile, hanya tag tertentu yang akan dimasukkan ke tabel shapefile.
->	Situs-situs yang tercantum di atas menyediakan shapefile dengan pengaturan
->	standar tag umum, tetapi jika Anda ingin mengekstrak tag tertentu Anda perlu
->	menggunakan salah satu layanan tertentu pada sesi selanjutnya atau mempelajari
->	bagaimana mengeksport data Anda sendiri.
+>Ingatlah bahwa fitur dalam OpenStreetMap memiliki jumlah tag "gratis" yang 
+>tidak terbatas, namun shapefile memiliki atribut yang disimpan dalam jumlah 
+>kolom yang terbatas. Hal ini dimaksudkan bahwa ketika data OSM dikonversi
+>ke dalam shapefile, hanya tag tertentu yang akan dimasukkan ke tabel shapefile.
+>Situs-situs yang tercantum di atas menyediakan shapefile dengan pengaturan
+>standar tag umum, tetapi jika Anda ingin mengekstrak tag tertentu Anda perlu
+>menggunakan salah satu layanan tertentu pada sesi selanjutnya atau mempelajari
+>bagaimana mengeksport data Anda sendiri.
 
 Ekstrak yang Disesuaikan
 -------------------------
+
 ### HOT Export
 [Humanitarian OpenStreetMap Team](http://hotosm.org) telah membuat layanan yang 
 memungkinakan pengguna memilih daerah yang mereka ingin ekstrak, dan juga menggunakan
-[JOSM Presets](/en/editing/josm-presets) untuk memilih tag yang sudah disesuaikan untuk
+[JOSM Presets](/bi/josm/josm-presets/) untuk memilih tag yang sudah disesuaikan untuk
 dimasukkan dalam ekstrak. Layanan yan tersedia untuk semua negara dimana HOT bekerja, di
 [export.hotosm.org](http://export.hotosm.org).
 

--- a/_posts/en/osm-data/0600-12-15-getting-data.md
+++ b/_posts/en/osm-data/0600-12-15-getting-data.md
@@ -14,6 +14,7 @@ that provide data extracts for an area of your choosing.
 
 Downloading Data Extracts
 --------------------------
+
 ### GeoFabrik
 [GeoFabrik](http://geofabrik.de) is a company which specializes in working
 with OpenStreetMap. They provide a variety of free extracts in shapefile and raw OSM format
@@ -22,23 +23,23 @@ GeoFabrik data is that it is updated every day, and it's easy and reliable. One 
 that the data is extracted by country, and not all countries are available.
 
 ### Metro Extracts
-[Another website created by Michal Migurksi](http://metro.teczno.com/) provides shapefiles for
-cities around the world. This is useful if you are looking for data extracts for a single city.
-The disadvantage to this site is that it is not updated regularly.
+[Another website maintained by Mapzen](https://mapzen.com/data/metro-extracts/) provides shapefiles for
+cities around the world, extracted weekly. This is useful if you are looking for data extracts for a single city.
 
->	Remember that features in OpenStreetMap have an unlimited number of "free" tags,
->	but shapefiles have attributes stored in a limited number of columns. This means
->	that when OSM data is converted into shapefiles, only the specified tags will be
->	included in the shapefile table. The websites listed above provide shapefiles
->	with a default set of common tags, but if you want to extract specific tags
->	you will need to use one of the more specialized services in the next section
->	or learn how to export the data yourself.
+>Remember that features in OpenStreetMap have an unlimited number of "free" tags,
+>but shapefiles have attributes stored in a limited number of columns. This means
+>that when OSM data is converted into shapefiles, only the specified tags will be
+>included in the shapefile table. The websites listed above provide shapefiles
+>with a default set of common tags, but if you want to extract specific tags
+>you will need to use one of the more specialized services in the next section
+>or learn how to export the data yourself.
 
 Customized Extracts
 -------------------
+
 ### HOT Exports
 The [Humanitarian OpenStreetMap Team](http://hotosm.org) has created a service that allows users
-to select the area that they want to extract, and also use [JOSM Presets](/en/editing/josm-presets)
+to select the area that they want to extract, and also use [JOSM Presets](/en/josm/josm-presets/)
 to select custom tags to be included in the extract. The service is available to all countries where
 HOT works, at [export.hotosm.org](http://export.hotosm.org).
 

--- a/_posts/ja/osm-data/0600-12-15-getting-data.md
+++ b/_posts/ja/osm-data/0600-12-15-getting-data.md
@@ -8,28 +8,31 @@ category: osm-data
 
 OSMデータの取得
 =================
+
 最新のOpenStreetMapデータを入手するには、データの配布を行っているウェブサイトを利用してダウンロードを行うのが簡単です。様々なサイトで配布されているデータを比較して、あなたが必要とする地域だけを切り出したデータをダウンロードしてください。
 
 抽出データのダウンロード
 --------------------------
+
 ### GeoFabrik
 [GeoFabrik](http://geofabrik.de) はOpenStreetMapを専門とする企業です。彼らは[ダウンロードウェブサイト](http://download.geofabrik.de)から、無償でshapefile形式や生のOSMフォーマットのデータ配布を行っています。GeoFabrikからのダウンロードは、日次でデータが更新されること、そして、なによりダウンロードが簡単で信頼性が高い、という点で大きな利点があります。逆に、抽出が国ごとであり、すべての国が対象になっていない、ということが、欠点といえば欠点といえます。
 
 ### Metro Extracts
 [Michal Migurksiさん作のサイト](http://metro.teczno.com/)では、世界各地の都市のshapefileが配布されています。特定の都市のデータだけが必要な場合は、このデータが有用でしょう。ただし、このサイトは不定期更新なのが欠点といえます。
 
->	Remember that features in OpenStreetMap have an unlimited number of "free" tags,
->	but shapefiles have attributes stored in a limited number of columns. This means
->	that when OSM data is converted into shapefiles, only the specified tags will be
->	included in the shapefile table. The websites listed above provide shapefiles
->	with a default set of common tags, but if you want to extract specific tags
->	you will need to use one of the more specialized services in the next section
->	or learn how to export the data yourself.
+>Remember that features in OpenStreetMap have an unlimited number of "free" tags,
+>but shapefiles have attributes stored in a limited number of columns. This means
+>that when OSM data is converted into shapefiles, only the specified tags will be
+>included in the shapefile table. The websites listed above provide shapefiles
+>with a default set of common tags, but if you want to extract specific tags
+>you will need to use one of the more specialized services in the next section
+>or learn how to export the data yourself.
 
 カスタマイズ可能なデータ抽出
 -------------------
+
 ### HOT Exports
-[OpenStreetMap人道支援チーム (HOT)](http://hotosm.org)は、ユーザごとに対象地域の変更が可能なデータ抽出サイトと、抽出時に含める指定タグを選択した[JOSMプリセット](/en/editing/josm-presets)を提供しています。[export.hotosm.org](http://export.hotosm.org)は、HOTが活動しているすべての地域で利用可能です。
+[OpenStreetMap人道支援チーム (HOT)](http://hotosm.org)は、ユーザごとに対象地域の変更が可能なデータ抽出サイトと、抽出時に含める指定タグを選択した[JOSMプリセット](/ja/josm/josm-presets/)を提供しています。[export.hotosm.org](http://export.hotosm.org)は、HOTが活動しているすべての地域で利用可能です。
 
 ![hot exports][]
 


### PR DESCRIPTION
Fixes header formatting, link to JOSM Presets module, and blockquote
formatting. Updates link to Metro Extracts (the old link is no longer
maintained by Michal Migurski) and associated text.