### PR TITLE
fix for search input box on smaller screens

### DIFF
--- a/_layouts/front-rtl.html
+++ b/_layouts/front-rtl.html
@@ -25,7 +25,7 @@ layout: default
       <div class='marginStart cell9 padAll'>
         <form class='searchbox rounded'>
           <span class='logo logo-search' style='margin-top: 0px;'></span>
-          <input id='search-field' type='text' name='search' class='default-value cell10'></input>
+          <input id='search-field' type='text' name='search' class='default-value'></input>
         </form>
       </div>
       <div id='front' class='marginStart cell9 padAll'>

--- a/_layouts/front.html
+++ b/_layouts/front.html
@@ -25,7 +25,7 @@ layout: default
       <div class='marginStart cell9 padAll'>
         <form class='searchbox rounded'>
           <span class='logo logo-search' style='margin-top: 0px;'></span>
-          <input id='search-field' type='text' name='search' class='default-value cell10'></input>
+          <input id='search-field' type='text' name='search' class='default-value'></input>
         </form>
       </div>
       <div id='front' class='marginStart cell9 padAll'>

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -480,10 +480,11 @@ a.license {
 
 .searchbox input {
   border:none;
-  padding:4px 20px 4px 0px;
   font-size:16px;
   font-family:'Source Sans Pro',sans-serif;
   background-color: #ffffff;
+  width: 70%;
+  vertical-align: middle;
 }
 
 .searchbox input:focus {

--- a/style.css
+++ b/style.css
@@ -473,10 +473,11 @@ a.license {
 
 .searchbox input {
   border:none;
-  padding:4px 0px 4px 20px;
   font-size:16px;
   font-family:'Source Sans Pro',sans-serif;
   background-color: #ffffff;
+  width: 70%;
+  vertical-align: middle;
 }
 
 .searchbox input:focus {


### PR DESCRIPTION
This is how search filed is displayed on my mobile:
<img src="https://user-images.githubusercontent.com/8467903/82814302-20cb9d80-9eac-11ea-9a4a-594030d1bfc2.png" height="50%" width="50%" />

Then it will look like this, however I currently set the width to 70%, I'm not sure whether there are other screens that 70% does fit for them or not.
<img src="https://user-images.githubusercontent.com/8467903/82814299-1f9a7080-9eac-11ea-8629-2fcf4efac9a4.png" height="50%" width="50%" />