### PR TITLE
Update 0500-12-06-remote-mapping_en.md

### DIFF
--- a/_posts/en/0500-12-06-remote-mapping_en.md
+++ b/_posts/en/0500-12-06-remote-mapping_en.md
@@ -31,7 +31,7 @@ In order to use the HOT Tasking Manager you need to sign up with OpenStreetMap (
 
 ### Editing Tools 
 
-[iD](http://learnosm.org/en/beginner/id-editor/) - the web-based editor created by [Mapbox](www.mapbox.com) with a very user-friendly interface. Generally considered the best editing tool to start with. You can launch this [interactive iD editor tutorial](http://ideditor.com/) to get acquainted with how to use it.  
+[iD](https://github.com/openstreetmap/iD/blob/develop/README.md) - the web-based editor created by [Mapbox](www.mapbox.com) with a very user-friendly interface. Generally considered the best editing tool to start with. You can launch this [interactive iD editor tutorial](http://ideditor.com/) to get acquainted with how to use it.  
 
 ![iDeditor](https://blog.openstreetmap.org/wp-content/uploads/2013/08/id-editor-sotm-us-2013-venue-screenshot.png)  
 


### PR DESCRIPTION
Since in the next paragraph the JOSM hyperlink is pointing to the download/developers site it is consistent to have the ID hyperlink doing the same.