### PR TITLE
Update 0500-10-25-tm-user_en.md

### DIFF
--- a/_posts/en/0500-10-25-tm-user_en.md
+++ b/_posts/en/0500-10-25-tm-user_en.md
@@ -73,22 +73,9 @@ The Tasking Manager is a special tool that coordinates mapping in OpenStreetMap.
 
 When you visit the [Tasking Manager](https://tasks.hotosm.org) homepage you can choose between the `Login` and the `Sign up` button in the upper right corner of the screen.
 
-In case you already have an OpenStreetMap account, press `Log in`. If you don't have an OpenStreetMap account yet, choose `Sign up`. Provide your email address and name and confirm.
-
-![TM4-user-guide-1][]
-
-
-![TM4-user-guide-2a][]
-![TM4-user-guide-2b][]
-
-A new tab will open allowing you to register on OpenStreetMap.org. Provide your account information and press the `Sign up` button at the bottom of the form. Verify your email address.
-
-![TM4-user-guide-3][]
-
-Close the tab and go back to the [Tasking Manager](https://tasks.hotosm.org). Click the button to `Log in` and authorize the application.
-
-![TM4-user-guide-4a][]
-![TM4-user-guide-4b][]
+* In case you already have an OpenStreetMap account, press `Log in`. See also the [QUICK START GUIDE](https://learnosm.org/en/coordination/tm-user/#quick-start-guide) step 4 and further.
+* If you don't have an OpenStreetMap account yet, choose `Sign up`. Provide your email address and name and confirm. 
+See also the [QUICK START GUIDE](https://learnosm.org/en/coordination/tm-user/#quick-start-guide) step 1 to 3.
 
 ## Settings
 


### PR DESCRIPTION
The login and sign up processes are described twice: QUICK START GUIDE and Tasking Manager Login. This makes the page unnessecary long, it is already a lot of scrolling to reach the bottom.

So i removed the 2nd description of the login proces. And add a link to the QUICK START GUIDE.

The page is shorter now and a few images that are duplicated are gone. Makes the page imo more usable.