### PR TITLE
Update 0500-10-20-remote_en.md

### DIFF
--- a/_posts/en/0500-10-20-remote_en.md
+++ b/_posts/en/0500-10-20-remote_en.md
@@ -77,7 +77,7 @@ Having selected the project you are going to work on, now select a square and th
 > If the boundary crosshatching is not visible, you may have installed the plugin '*Download OSM data continuously*'. To correct this you will need to remove the tick for this plugin under the File menu of JOSM, delete the downloaded data, and download again using the Tasking Manager.  
 2.  The scale of your view is indicated here. This is a very small square, with a figure of 40.8 metres - this figure is often several kilometres.  
 3.  Several features already exist within the OpenStreetMap database, and these have been loaded. We will explore them in a moment.
-4.  There is no background imagery loaded on this occasion and we will have to load it manually - the instructions for this particular project show that bing imagery is to be loaded, and this can be quickly loaded by clicking on the word 'imagery' and then selecting 'bing' from the dropdown list. You may find that zooming out (roll the mouse centre wheel towards you) and then zooming in again helps the imagery to load quickly. 
+4.  There is no background imagery loaded on this occasion and we will have to load it manually - the instructions for this particular project show that bing imagery is to be loaded, and this can be quickly loaded by clicking on the menu-item 'imagery' and then selecting 'bing' from the dropdown list. You may find that zooming out (roll the mouse centre wheel towards you) and then zooming in again helps the imagery to load quickly. 
 
 ### Alternate initial view - JOSM
 


### PR DESCRIPTION
"the word ‘imagery’" is unclear about what is meant, namely the menu-item.

What also could be imo better is the order of certain paragraphs. 

The par. "Remote Mapping - Starting to map" is clearly aimed at beginner mappers. But it is followed by an explanation for Josm. This feels to me a bit awkward. 

What do you think: should we put all the ID explanations first (Initial view, alternate intitial view, checking etc.), followed by the Josm ones?

I didn't change it yet, i first like to hear your opinion about this.