### PR TITLE
Update 0450-10-05-saving_en.md

### DIFF
--- a/_posts/en/0450-10-05-saving_en.md
+++ b/_posts/en/0450-10-05-saving_en.md
@@ -47,7 +47,7 @@ When you think the square is finished, add a comment and mark the square as comp
 
 If you select;
 
-- **¨Yes¨ on the question ¨Is this task completely mapped?¨** the square you were working on will turn yellow to show it is complete and awaiting validation.  
+- **¨Yes¨ on the question ¨Is this task completely mapped?¨** the square you were working on will turn blue to show it is complete and awaiting validation.  
 - **¨No¨ on the question ¨Is this task completely mapped?¨** the square will return to it's previous colour to show it needs more work. It is very helpful if your comment lets the next mapper know what needs to be done, such as  
     - "There are more buildings to trace in the bottom right corner of the square, but I've run out of time"  
 


### PR DESCRIPTION
Minor glitch and wrong image (referring validation instead of mapping).

Replacement image (20190625-TM-stop-mapping-800px.png) via dm slack.