### PR TITLE
Update style.css for preformatted text

### DIFF
--- a/style.css
+++ b/style.css
@@ -235,6 +235,7 @@ pre {
   padding: 10px;
   margin: 10px 0;
   font-family: monospace;
+  white-space: pre-wrap;
 }
 
 /* footnotes in the google docs */


### PR DESCRIPTION
When displaying preformatted text on a smaller screen the end of longer lines  is cut off the screen and not visible.
Eg the line `url="http://overpass-api.de/api/interpreter...` on page https://learnosm.org/en/osm-data/getting-data/

I added a `white-space: pre-wrap;` so that a horizontal scrollbar makes it possible to see the whole line.